### PR TITLE
Add -dev1 suffix for python sdk

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ signing.gnupg.executable=gpg
 signing.gnupg.useLegacyGpg=true
 
 version=2.35.0
-sdk_version=2.35.0
+sdk_version=2.35.0.dev1
 
 javaVersion=1.8
 

--- a/sdks/python/apache_beam/version.py
+++ b/sdks/python/apache_beam/version.py
@@ -17,4 +17,4 @@
 
 """Apache Beam SDK version information and utilities."""
 
-__version__ = '2.35.0'
+__version__ = '2.35.0.dev1'


### PR DESCRIPTION
This is to:
* make it explicit that we have a custom Beam Python SDK, and
* to prevent clashes with official Beam-2.35.0 library